### PR TITLE
feat: add Pixi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Supported formats:
 -   [PEP 631](https://peps.python.org/pep-0631/) – `pyproject.toml`'s `project.dependencies`/`project.optional-dependencies`
 -   [PEP 735](https://peps.python.org/pep-0735/) - `pyproject.toml`'s `dependency-groups`
 -   [uv](https://docs.astral.sh/uv/reference/settings/) - `pyproject.toml`'s `tool.uv.constraint-dependencies`/`tool.uv.dev-dependencies`/`tool.uv.override-dependencies`
--   [Pixi](https://pixi.sh/latest/advanced/pyproject_toml/) - `pyproject.toml`'s `tool.pixi.dependencies`/`tool.pixi.feature.*.dependencies`
+-   [Pixi](https://pixi.sh/latest/advanced/pyproject_toml/) - `pyproject.toml`'s `tool.pixi.pypi-dependencies`
 
 This extension depends on [Microsoft's official Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) for `pip requirements` language support.

--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ Supported formats:
 -   [PEP 631](https://peps.python.org/pep-0631/) – `pyproject.toml`'s `project.dependencies`/`project.optional-dependencies`
 -   [PEP 735](https://peps.python.org/pep-0735/) - `pyproject.toml`'s `dependency-groups`
 -   [uv](https://docs.astral.sh/uv/reference/settings/) - `pyproject.toml`'s `tool.uv.constraint-dependencies`/`tool.uv.dev-dependencies`/`tool.uv.override-dependencies`
+-   [Pixi](https://pixi.sh/v0.25.0/advanced/pyproject_toml/) - `pyproject.toml`'s `tool.pixi.dependencies`/`tool.pixi.feature.*.dependencies`
 
 This extension depends on [Microsoft's official Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) for `pip requirements` language support.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Supported formats:
 -   [PEP 631](https://peps.python.org/pep-0631/) – `pyproject.toml`'s `project.dependencies`/`project.optional-dependencies`
 -   [PEP 735](https://peps.python.org/pep-0735/) - `pyproject.toml`'s `dependency-groups`
 -   [uv](https://docs.astral.sh/uv/reference/settings/) - `pyproject.toml`'s `tool.uv.constraint-dependencies`/`tool.uv.dev-dependencies`/`tool.uv.override-dependencies`
--   [Pixi](https://pixi.sh/v0.25.0/advanced/pyproject_toml/) - `pyproject.toml`'s `tool.pixi.dependencies`/`tool.pixi.feature.*.dependencies`
+-   [Pixi](https://pixi.sh/latest/advanced/pyproject_toml/) - `pyproject.toml`'s `tool.pixi.dependencies`/`tool.pixi.feature.*.dependencies`
 
 This extension depends on [Microsoft's official Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) for `pip requirements` language support.

--- a/src/parsing/pyproject.test.ts
+++ b/src/parsing/pyproject.test.ts
@@ -205,3 +205,43 @@ describe('extractRequirementsFromPyprojectToml with PEP 735', () => {
         ])
     })
 })
+
+describe('extractRequirementsFromPyprojectToml with Pixi', () => {
+    it('should extract basic requirements', () => {
+        const document = makeTextDocumentLike([
+            '[tool.pixi]',
+            'name = "pixi-demo"',
+            'version = "0.1.0"',
+            'description = "Test"',
+            'authors = ["Michael Matloka"]',
+            '',
+            '[tool.pixi.dependencies]',
+            'requests = "^2.22.0"',
+            'foo = "<6.6.6"',
+        ])
+
+        const result = extractRequirementsFromPyprojectToml(document)
+
+        expect(result).toEqual([
+            [{ name: 'requests', type: 'ProjectName' }, [7, 0, 7, 20]],
+            [{ name: 'foo', type: 'ProjectName' }, [8, 0, 8, 14]],
+        ])
+    })
+
+    it('should extract requirements from feature', () => {
+        const document = makeTextDocumentLike([
+            '[tool.pixi]',
+            'name = "pixi-demo"',
+            'version = "0.1.0"',
+            'description = "Test"',
+            'authors = ["Michael Matloka"]',
+            '',
+            '[tool.pixi.feature.test.dependencies]',
+            'baz = ">6.6.6"',
+        ])
+
+        const result = extractRequirementsFromPyprojectToml(document)
+
+        expect(result).toEqual([[{ name: 'baz', type: 'ProjectName' }, [7, 0, 7, 14]]])
+    })
+})

--- a/src/parsing/pyproject.test.ts
+++ b/src/parsing/pyproject.test.ts
@@ -215,7 +215,7 @@ describe('extractRequirementsFromPyprojectToml with Pixi', () => {
             'description = "Test"',
             'authors = ["Michael Matloka"]',
             '',
-            '[tool.pixi.dependencies]',
+            '[tool.pixi.pypi-dependencies]',
             'requests = "^2.22.0"',
             'foo = "<6.6.6"',
         ])
@@ -226,22 +226,5 @@ describe('extractRequirementsFromPyprojectToml with Pixi', () => {
             [{ name: 'requests', type: 'ProjectName' }, [7, 0, 7, 20]],
             [{ name: 'foo', type: 'ProjectName' }, [8, 0, 8, 14]],
         ])
-    })
-
-    it('should extract requirements from feature', () => {
-        const document = makeTextDocumentLike([
-            '[tool.pixi]',
-            'name = "pixi-demo"',
-            'version = "0.1.0"',
-            'description = "Test"',
-            'authors = ["Michael Matloka"]',
-            '',
-            '[tool.pixi.feature.test.dependencies]',
-            'baz = ">6.6.6"',
-        ])
-
-        const result = extractRequirementsFromPyprojectToml(document)
-
-        expect(result).toEqual([[{ name: 'baz', type: 'ProjectName' }, [7, 0, 7, 14]]])
     })
 })

--- a/src/parsing/pyproject.ts
+++ b/src/parsing/pyproject.ts
@@ -68,25 +68,20 @@ class PyprojectTOMLVisitor implements Visitor<TOMLNode> {
     }
 
     private potentiallyRegisterPixiDependency(node: TOMLTable | TOMLKeyValue): void {
-        if (this.pathStack[0] === 'tool' && this.pathStack[1] === 'pixi') {
-            let projectName: string | undefined
-            if (
-                (this.pathStack[2] as string) === 'pypi-dependencies' &&
-                this.pathStack.length === 4 &&
-                typeof this.pathStack[3] === 'string'
-            ) {
-                // Basic dependencies
-                projectName = this.pathStack[3]
-            }
-            if (projectName) {
-                this.dependencies.push([
-                    {
-                        name: projectName,
-                        type: 'ProjectName',
-                    },
-                    [node.loc.start.line - 1, node.loc.start.column, node.loc.end.line - 1, node.loc.end.column],
-                ])
-            }
+        if (
+            this.pathStack[0] === 'tool' &&
+            this.pathStack[1] === 'pixi' &&
+            this.pathStack[2] === 'pypi-dependencies' &&
+            this.pathStack[3] &&
+            typeof this.pathStack[3] === 'string'
+        ) {
+            this.dependencies.push([
+                {
+                    name: this.pathStack[3],
+                    type: 'ProjectName',
+                },
+                [node.loc.start.line - 1, node.loc.start.column, node.loc.end.line - 1, node.loc.end.column],
+            ])
         }
     }
 

--- a/src/parsing/pyproject.ts
+++ b/src/parsing/pyproject.ts
@@ -69,27 +69,15 @@ class PyprojectTOMLVisitor implements Visitor<TOMLNode> {
 
     private potentiallyRegisterPixiDependency(node: TOMLTable | TOMLKeyValue): void {
         if (this.pathStack[0] === 'tool' && this.pathStack[1] === 'pixi') {
-            const projectName: string | undefined = (() => {
-                if (
-                    (this.pathStack[2] as string) === 'dependencies' &&
-                    this.pathStack.length === 4 &&
-                    typeof this.pathStack[3] === 'string'
-                ) {
-                    // Basic dependencies
-                    return this.pathStack[3]
-                }
-                if (
-                    this.pathStack[2] === 'feature' &&
-                    this.pathStack[4] === 'dependencies' &&
-                    this.pathStack.length === 6 &&
-                    typeof this.pathStack[5] === 'string'
-                ) {
-                    // Dependency feature
-                    return this.pathStack[5]
-                }
-                return undefined
-            })()
-
+            let projectName: string | undefined
+            if (
+                (this.pathStack[2] as string) === 'pypi-dependencies' &&
+                this.pathStack.length === 4 &&
+                typeof this.pathStack[3] === 'string'
+            ) {
+                // Basic dependencies
+                projectName = this.pathStack[3]
+            }
             if (projectName) {
                 this.dependencies.push([
                     {


### PR DESCRIPTION
This PR adds a support for [Pixi](https://pixi.sh/latest/)'s [pyproject.toml](https://pixi.sh/latest/advanced/pyproject_toml/).

```toml
[project]
name = "pixi-py"
version = "0.1.0"
requires-python = ">= 3.11"

[tool.pixi.dependencies]
black = ">=24.4.2,<25"
fastapi = ">=0.112.0,<0.113"

[tool.pixi.feature.test.dependencies]
pytest = "*"
```

![Screenshot 2025-02-09 at 9 25 16](https://github.com/user-attachments/assets/50aa84f0-15fb-4ca7-85c1-a3bb4fd3fdde)

Some notes:

- This PR DOES NOT add support for `pixi.toml`.
- Pixi uses Conda (conda-forge) by default and so there can be a diff between Conda and PyPI. (They are synced in most cases but)
