### PR TITLE
Provide available versions via code completion #17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "lru-cache": "^10.2.0",
                 "node-fetch": "^3.3.2",
                 "pip-requirements-js": "^0.2.1",
+                "semver": "^7.7.2",
                 "toml": "^3.0.0",
                 "toml-eslint-parser": "^0.9.3",
                 "wretch": "^2.6.0"
@@ -23,6 +24,7 @@
                 "@types/jest": "^29.0.3",
                 "@types/node": "^17.0.21",
                 "@types/node-fetch": "^2.6.4",
+                "@types/semver": "^7.7.1",
                 "@types/vscode": "^1.45.0",
                 "@typescript-eslint/eslint-plugin": "^5.13.0",
                 "@typescript-eslint/parser": "^5.13.0",
@@ -2867,6 +2869,13 @@
                 "@types/node": "*",
                 "form-data": "^3.0.0"
             }
+        },
+        "node_modules/@types/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/stack-utils": {
             "version": "2.0.1",
@@ -7751,10 +7760,9 @@
             "dev": true
         },
         "node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-            "dev": true,
+            "version": "7.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "@types/jest": "^29.0.3",
         "@types/node": "^17.0.21",
         "@types/node-fetch": "^2.6.4",
+        "@types/semver": "^7.7.1",
         "@types/vscode": "^1.45.0",
         "@typescript-eslint/eslint-plugin": "^5.13.0",
         "@typescript-eslint/parser": "^5.13.0",
@@ -77,6 +78,7 @@
         "lru-cache": "^10.2.0",
         "node-fetch": "^3.3.2",
         "pip-requirements-js": "^0.2.1",
+        "semver": "^7.7.2",
         "toml": "^3.0.0",
         "toml-eslint-parser": "^0.9.3",
         "wretch": "^2.6.0"


### PR DESCRIPTION
This adds a `CompletionItemProvider` to provide available package versions after "=". The versions are sorted semver reverse if possible.